### PR TITLE
Replaced `sed` separator `|` -> `#`

### DIFF
--- a/nix-fix-hash.sh
+++ b/nix-fix-hash.sh
@@ -66,7 +66,7 @@ if [[ -z "$new_hash" ]]; then
 fi
 info "new hash: $new_hash"
 
-if ! sed -i -e "s|${old_hash}|${new_hash}|g" "$path/flake.nix"; then
+if ! sed -i -e "s#${old_hash}#${new_hash}#g" "$path/flake.nix"; then
     error "failed to update hash in $path"
 fi
 


### PR DESCRIPTION
I have no idea why this is a problem for SED, but locally, I have two hashes (old/new) both containing `/`, and that seems to mess with it wildly.

Using `#` as a separator seems to change the behavior, although I'm not sure why :-\